### PR TITLE
Fix breadcrumbs

### DIFF
--- a/dynamicsax2012-technet/breadcrumb/toc.yml
+++ b/dynamicsax2012-technet/breadcrumb/toc.yml
@@ -1,1 +1,3 @@
-[]
+- name: Microsoft Dynamics AX 2012
+  tocHref: /dynamicsax-2012/
+  topicHref: /dynamicsax-2012/index

--- a/dynamicsax2012-technet/docfx.json
+++ b/dynamicsax2012-technet/docfx.json
@@ -45,7 +45,6 @@
                                         ],
                   "globalMetadata":  {
                                          "breadcrumb_path":  "/dynamicsax-2012/appuser-itpro/breadcrumb/toc.json",
-                                         "extendBreadcrumb":  true,
                                          "ROBOTS":  "INDEX,FOLLOW",
                                          "is_archived":  false,
                                          "ms.date":  "06/21/2018",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.