### PR TITLE
Add globalMetadat 'NOINDEXKS' for DynamicsAX2012-technet

### DIFF
--- a/dynamicsax2012-technet/docfx.json
+++ b/dynamicsax2012-technet/docfx.json
@@ -51,7 +51,8 @@
                                          "ms.date":  "06/21/2018",
                                          "ms.topic":  "conceptual",
                                          "feedback_system": "none",
-                                         "uhfHeaderId": "MSDocsHeader-Dynamics365"
+                                         "uhfHeaderId": "MSDocsHeader-Dynamics365",
+                                         "NOINDEXKS": true
                                      },
                   "fileMetadata":  {
                             "searchScope": {


### PR DESCRIPTION
- content in DynamicsAX2012-technet seems stale and without any update in the past months. 
- KS should exclude this docset without indexing.